### PR TITLE
add '-j' flag to 'jq' to avoid appending newline to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WIP Toolbox
 Canonical way to collapse a TDX [measurements.json](docs/measurements.json) file into a single hash, in a reproducible way:
 
 ```bash
-cat measurements.json | jq --sort-keys --compact-output | sha256sum
+cat measurements.json | jq --sort-keys --compact-output --join-output | sha256sum
 ```
 
 ## Usage


### PR DESCRIPTION
## 📝 Summary

Improve `measurements_hash` generation definition.

## ⛱ Motivation and Context

It's much cleaner to avoid trailing newline, this way it's much more natural for implementation in other languages

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
