### PR TITLE
HTTP Basic auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /cert.pem
 /key.pem
 /pipe.fifo
+/basic-auth-secret.txt

--- a/README.md
+++ b/README.md
@@ -93,13 +93,17 @@ $ curl -v -X POST -d "@README.md" localhost:3535/api/v1/file-upload/testfile
 
 ## HTTP Basic Auth
 
-All API endpoints can be protected with HTTP Basic Auth. The secret needs to be set once, either via file or via API.
-If set via API, it will be persisted in a file specified in the config file.
+All API endpoints can be protected with HTTP Basic Auth.
+
+The API endpoints are initially unauthenticated, until a secret is configured
+either via file or via API. If the secret is configured via API, the SHA256
+hash is be stored in a file (specified in the config file) to enable basic auth protection
+across restarts.
 
 The config file ([systemapi-config.toml](./systemapi-config.toml)) includes a `basic_auth_secret_path`.
-- If this file is specified but doesn't exist, system-api will not start
-- If the file exists and is empty, then the APIs are unauthenticated until a secret is set
-- If the file exists and is not empty, then the APIs are authenticated with the secret in this file
+- If this file is specified but doesn't exist, system-api will not start and log an error.
+- If the file exists and is empty, then the APIs are unauthenticated until a secret is configured.
+- If the file exists and is not empty, then the APIs are authenticated for passwords that match the hash in this file.
 
 ```bash
 # Set `basic_auth_secret_path` in the config file and create it empty
@@ -110,7 +114,7 @@ vi systemapi-config.toml
 $ go run cmd/system-api/main.go --config systemapi-config.toml
 
 # Initially, requests are unauthenticated
-$ curl localhost:3535/api/v1/livez
+$ curl localhost:3535/livez
 
 # Set the basic auth secret
 $ curl -d "foobar" localhost:3535/api/v1/set-basic-auth

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ It currently does the following things:
  hashes, etc.
 - **Actions**: Ability to execute shell commands via API
 - **Configuration** through file uploads
-
-Future features:
-
-- Set a password for http-basic-auth (persisted, for all future requests)
+- **HTTP Basic Auth** for API endpoints
 
 ---
 
@@ -92,4 +89,32 @@ $ go run cmd/system-api/main.go --config systemapi-config.toml
 
 # Execute the example action
 $ curl -v -X POST -d "@README.md" localhost:3535/api/v1/file-upload/testfile
+```
+
+## HTTP Basic Auth
+
+All API endpoints can be protected with HTTP Basic Auth. The secret needs to be set once, either via file or via API.
+If set via API, it will be persisted in a file specified in the config file.
+
+The config file ([systemapi-config.toml](./systemapi-config.toml)) includes a `basic_auth_secret_path`.
+- If this file is specified but doesn't exist, system-api will not start
+- If the file exists and is empty, then the APIs are unauthenticated until a secret is set
+- If the file exists and is not empty, then the APIs are authenticated with the secret in this file
+
+```bash
+# Set `basic_auth_secret_path` in the config file and create it empty
+touch .basic-auth-secret
+vi systemapi-config.toml
+
+# Start the server,
+$ go run cmd/system-api/main.go --config systemapi-config.toml
+
+# Initially, requests are unauthenticated
+$ curl localhost:3535/api/v1/livez
+
+# Set the basic auth secret
+$ curl -d "foobar" localhost:3535/api/v1/set-basic-auth
+
+# Now requests are authenticated
+$ curl -u admin:foobar -v localhost:3535/livez
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ curl -v -X POST -d "@README.md" localhost:3535/api/v1/file-upload/testfile
 All API endpoints can be protected with HTTP Basic Auth.
 
 The API endpoints are initially unauthenticated, until a secret is configured
-either via file or via API. If the secret is configured via API, the SHA256
+either via file or via API. If the secret is configured via API, the salted SHA256
 hash is be stored in a file (specified in the config file) to enable basic auth protection
 across restarts.
 

--- a/cmd/system-api/main.go
+++ b/cmd/system-api/main.go
@@ -91,11 +91,7 @@ func runCli(cCtx *cli.Context) (err error) {
 	)
 
 	// Setup and start the server (in the background)
-	cfg := &systemapi.HTTPServerConfig{
-		Log:    log,
-		Config: config,
-	}
-	server, err := systemapi.NewServer(cfg)
+	server, err := systemapi.NewServer(log, config)
 	if err != nil {
 		log.Error("Error creating server", "err", err)
 		return err

--- a/cmd/system-api/main.go
+++ b/cmd/system-api/main.go
@@ -97,6 +97,7 @@ func runCli(cCtx *cli.Context) (err error) {
 	}
 	server, err := systemapi.NewServer(cfg)
 	if err != nil {
+		log.Error("Error creating server", "err", err)
 		return err
 	}
 	go server.Start()

--- a/systemapi-config.toml
+++ b/systemapi-config.toml
@@ -5,14 +5,19 @@ pprof = true
 log_json = false
 log_debug = true
 
-# Enable HTTP Basic auth by setting a file for the hashed secret
-basic_auth_secret_path = "basic-auth-secret.txt"
+# HTTP Basic Auth
+basic_auth_secret_path = "basic-auth-secret.txt" # basic auth is supported if a path is provided
+basic_auth_secret_salt = "D;%yL9TS:5PalS/d"      # use a random string for the salt
+
+# HTTP server timeouts
+# http_read_timeout_ms = 2500
+# http_write_timeout_ms = 2500
 
 [actions]
+echo_test = "echo test"
 # reboot = "reboot"
 # rbuilder_restart = "/etc/init.d/rbuilder restart"
 # rbuilder_stop = "/etc/init.d/rbuilder stop"
-echo_test = "echo test"
 
 [file_uploads]
 testfile = "/tmp/testfile.txt"

--- a/systemapi-config.toml
+++ b/systemapi-config.toml
@@ -1,11 +1,12 @@
 [general]
 listen_addr = "0.0.0.0:3535"
 pipe_file = "pipe.fifo"
+pprof = true
 log_json = false
 log_debug = true
 
-# The path to the secret file used for basic auth
-basic_auth_secret_path = "/tmp/basic_auth_secret"
+# Enable HTTP Basic auth by setting a file for the hashed secret
+basic_auth_secret_path = "basic-auth-secret.txt"
 
 [actions]
 # reboot = "reboot"

--- a/systemapi-config.toml
+++ b/systemapi-config.toml
@@ -4,6 +4,9 @@ pipe_file = "pipe.fifo"
 log_json = false
 log_debug = true
 
+# The path to the secret file used for basic auth
+basic_auth_secret_path = "/tmp/basic_auth_secret"
+
 [actions]
 # reboot = "reboot"
 # rbuilder_restart = "/etc/init.d/rbuilder restart"

--- a/systemapi/config.go
+++ b/systemapi/config.go
@@ -11,6 +11,8 @@ type systemAPIConfigGeneral struct {
 	PipeFile   string `toml:"pipe_file"`
 	LogJSON    bool   `toml:"log_json"`
 	LogDebug   bool   `toml:"log_debug"`
+
+	BasicAuthSecretPath string `toml:"basic_auth_secret_path"`
 }
 
 type SystemAPIConfig struct {

--- a/systemapi/config.go
+++ b/systemapi/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type systemAPIConfigGeneral struct {
-	ListenAddr string `toml:"listen_addr"`
-	PipeFile   string `toml:"pipe_file"`
-	LogJSON    bool   `toml:"log_json"`
-	LogDebug   bool   `toml:"log_debug"`
+	ListenAddr  string `toml:"listen_addr"`
+	PipeFile    string `toml:"pipe_file"`
+	LogJSON     bool   `toml:"log_json"`
+	LogDebug    bool   `toml:"log_debug"`
+	EnablePprof bool   `toml:"pprof"` // Enables pprof endpoints
 
 	BasicAuthSecretPath string `toml:"basic_auth_secret_path"`
 }

--- a/systemapi/config.go
+++ b/systemapi/config.go
@@ -14,6 +14,10 @@ type systemAPIConfigGeneral struct {
 	EnablePprof bool   `toml:"pprof"` // Enables pprof endpoints
 
 	BasicAuthSecretPath string `toml:"basic_auth_secret_path"`
+	BasicAuthSecretSalt string `toml:"basic_auth_secret_salt"`
+
+	HTTPReadTimeoutMillis  int `toml:"http_read_timeout_ms"`
+	HTTPWriteTimeoutMillis int `toml:"http_write_timeout_ms"`
 }
 
 type SystemAPIConfig struct {

--- a/systemapi/middleware.go
+++ b/systemapi/middleware.go
@@ -1,20 +1,22 @@
 package systemapi
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 )
 
 // BasicAuth implements a simple middleware handler for adding basic http auth to a route.
-func BasicAuth(realm string, getCreds func() map[string]string) func(next http.Handler) http.Handler {
+func BasicAuth(realm string, getHashedCredentials func() map[string]string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Loading credentials dynamically because they can be updated at runtime
-			creds := getCreds()
+			hashedCredentials := getHashedCredentials()
 
 			// If no credentials are set, just pass through (unauthenticated)
-			if len(creds) == 0 {
+			if len(hashedCredentials) == 0 {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -26,9 +28,14 @@ func BasicAuth(realm string, getCreds func() map[string]string) func(next http.H
 				return
 			}
 
+			// Hash the password and see if credentials are allowed
+			h := sha256.New()
+			h.Write([]byte(pass))
+			userPassHash := hex.EncodeToString(h.Sum(nil))
+
 			// Compare to allowed credentials
-			credPass, credUserOk := creds[user]
-			if !credUserOk || subtle.ConstantTimeCompare([]byte(pass), []byte(credPass)) != 1 {
+			credPassHash, credUserOk := hashedCredentials[user]
+			if !credUserOk || subtle.ConstantTimeCompare([]byte(userPassHash), []byte(credPassHash)) != 1 {
 				basicAuthFailed(w, realm)
 				return
 			}

--- a/systemapi/middleware.go
+++ b/systemapi/middleware.go
@@ -1,0 +1,41 @@
+package systemapi
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+)
+
+// BasicAuth implements a simple middleware handler for adding basic http auth to a route.
+func BasicAuth(realm string, getCreds func() map[string]string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			creds := getCreds()
+
+			if len(creds) == 0 {
+				// if no credentials are set, just pass through
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			user, pass, ok := r.BasicAuth()
+			if !ok {
+				basicAuthFailed(w, realm)
+				return
+			}
+
+			credPass, credUserOk := creds[user]
+			if !credUserOk || subtle.ConstantTimeCompare([]byte(pass), []byte(credPass)) != 1 {
+				basicAuthFailed(w, realm)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func basicAuthFailed(w http.ResponseWriter, realm string) {
+	w.Header().Add("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+	w.WriteHeader(http.StatusUnauthorized)
+}

--- a/systemapi/middleware.go
+++ b/systemapi/middleware.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BasicAuth implements a simple middleware handler for adding basic http auth to a route.
-func BasicAuth(realm string, getHashedCredentials func() map[string]string) func(next http.Handler) http.Handler {
+func BasicAuth(realm, salt string, getHashedCredentials func() map[string]string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Loading credentials dynamically because they can be updated at runtime
@@ -31,6 +31,7 @@ func BasicAuth(realm string, getHashedCredentials func() map[string]string) func
 			// Hash the password and see if credentials are allowed
 			h := sha256.New()
 			h.Write([]byte(pass))
+			h.Write([]byte(salt))
 			userPassHash := hex.EncodeToString(h.Sum(nil))
 
 			// Compare to allowed credentials

--- a/systemapi/server.go
+++ b/systemapi/server.go
@@ -98,6 +98,10 @@ func (s *Server) loadBasicAuthSecretFromFile() error {
 	}
 
 	s.basicAuthHash = string(secret)
+	if len(s.basicAuthHash) != 64 {
+		return fmt.Errorf("basic auth secret in %s does not look like a SHA256 hash (must be 64 characters)", s.cfg.General.BasicAuthSecretPath)
+	}
+
 	if len(secret) == 0 {
 		s.log.Info("Basic auth file without secret loaded, auth disabled until secret is configured", "file", s.cfg.General.BasicAuthSecretPath)
 	} else {

--- a/systemapi/server_test.go
+++ b/systemapi/server_test.go
@@ -1,0 +1,116 @@
+package systemapi
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/flashbots/system-api/common"
+	"github.com/go-chi/httplog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func getTestLogger() *httplog.Logger {
+	return common.SetupLogger(&common.LoggingOpts{
+		Debug: true,
+		JSON:  false,
+	})
+}
+
+func getTestConfig() *HTTPServerConfig {
+	return &HTTPServerConfig{
+		Log:    getTestLogger(),
+		Config: NewSystemAPIConfig(),
+	}
+}
+
+func TestGeneralHandlers(t *testing.T) {
+	// Create the config
+	cfg := getTestConfig()
+
+	// Instantiate the server
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+	router := srv.getRouter()
+
+	// Test /livez
+	req, err := http.NewRequest(http.MethodGet, "/livez", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Test /api/v1/events
+	req, err = http.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	require.NoError(t, err)
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	body, err := io.ReadAll(rr.Body)
+	require.NoError(t, err)
+	require.Equal(t, "[]\n", string(body))
+
+	// Add an event
+	req, err = http.NewRequest(http.MethodGet, "/api/v1/new_event?message=foo", nil)
+	require.NoError(t, err)
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, srv.events, 1)
+}
+
+func TestBasicAuth(t *testing.T) {
+	basicAuthSecret := []byte("secret")
+	tempDir := t.TempDir()
+
+	// Create the config
+	cfg := getTestConfig()
+	cfg.Config.General.BasicAuthSecretPath = tempDir + "/basic_auth_secret"
+
+	// Create the temporary file to store the basic auth secret
+	err := os.WriteFile(cfg.Config.General.BasicAuthSecretPath, []byte{}, 0o600)
+	require.NoError(t, err)
+
+	// Instantiate the server
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+	router := srv.getRouter()
+
+	getLiveZ := func(basicAuthUser, basicAuthPass string) int {
+		req, err := http.NewRequest(http.MethodGet, "/livez", nil)
+		if basicAuthUser != "" {
+			req.SetBasicAuth(basicAuthUser, basicAuthPass)
+		}
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	// Initially, /livez should work without basic auth
+	require.Equal(t, http.StatusOK, getLiveZ("", ""))
+
+	// Set a basic auth secret
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/set-basic-auth", bytes.NewReader(basicAuthSecret))
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify secretFromFile was written to file
+	secretFromFile, err := os.ReadFile(cfg.Config.General.BasicAuthSecretPath)
+	require.NoError(t, err)
+	require.Equal(t, basicAuthSecret, secretFromFile)
+
+	// From here on, /livez shoud fail without basic auth
+	require.Equal(t, http.StatusUnauthorized, getLiveZ("", ""))
+
+	// /livez should work with basic auth
+	require.Equal(t, http.StatusOK, getLiveZ("admin", string(basicAuthSecret)))
+
+	// /livez should now work with invalid basic auth credentials
+	require.Equal(t, http.StatusUnauthorized, getLiveZ("admin1", string(basicAuthSecret)))
+}


### PR DESCRIPTION
## 📝 Summary

Enables basic auth support for API requests. 

The basic auth password is configurable through API and/or file. If set via API, the salted hash is stored in the file to persist across reboots.

Config-file updates:

```toml
[general]
# HTTP Basic Auth
basic_auth_secret_path = "basic-auth-secret.txt" # basic auth is supported if a path is provided
basic_auth_secret_salt = "D;%yL9TS:5PalS/d"      # use a random string for the salt
```

`basic_auth_secret_path` specifies the file to store the salted, hashed secret in. It's loaded (or created) on startup.
- if the file is not empty, API requests need to include a http basic auth password that matches that sha256 hash (user `admin`)
- if empty, no authentication is required for API requests until secret is configured through API or file. if `/api/v1/set-basic-auth` is called, it uses the payload as secret (immediately) and writes the hash of the secret it to the file (for reuse across restarts).
- if file does not exist, it is created (empty)

Only the salted SHA256 hash of the password is stored, both in the file as well as in memory.

The secret can be overwritten (updated) via API call, if the request provides the previous http basic auth secret.

Also added tests and updated the README.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
