### PR TITLE
Event log: enable custom timestamp (via message prefix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ $ echo "1634966400 this is a test" > pipe.fifo
 
 # Query events
 $ curl localhost:3535/logs
-2024-11-21T19:48:04Z     hello world
-2021-10-23T05:20:00Z     this is a test          <--- custom timestamp on this entry
+2024-11-22T13:50:09Z     hello world
+2021-10-23T05:20:00Z     1634966400 this is a test      <--- custom timestamp on this entry
 ```
 
 ## Actions

--- a/README.md
+++ b/README.md
@@ -63,10 +63,31 @@ $ curl localhost:3535/logs
 2024-10-23T12:04:07Z     this is a test
 ```
 
- ## Actions
+#### Event timestamps
 
- Actions are shell commands that can be executed via API. The commands are defined in the config file,
- see [systemapi-config.toml](./systemapi-config.toml) for examples.
+By default, events are timestamped with the current time. However, the timestamp can be overridden by
+providing a valid unix timestamp (in seconds or milliseconds) as first part of the message:
+
+```bash
+# Start the server
+$ go run cmd/system-api/main.go
+
+# Add regular event
+$ echo "hello world" > pipe.fifo
+
+# Add event with custom timestamp
+$ echo "1634966400 this is a test" > pipe.fifo
+
+# Query events
+$ curl localhost:3535/logs
+2024-11-21T19:48:04Z     hello world
+2021-10-23T05:20:00Z     this is a test          <--- custom timestamp on this entry
+```
+
+## Actions
+
+Actions are shell commands that can be executed via API. The commands are defined in the config file,
+see [systemapi-config.toml](./systemapi-config.toml) for examples.
 
 Actions are recorded in the event log.
 

--- a/systemapi/server.go
+++ b/systemapi/server.go
@@ -222,11 +222,9 @@ func (s *Server) addEvent(event Event) {
 		if len(timestampStr) == 10 {
 			// timestamp in seconds, update event
 			event.ReceivedAt = time.Unix(timeInt, 0).UTC()
-			event.Message = strings.TrimSpace(event.Message[len(timestampStr):])
 		} else if len(timestampStr) == 13 {
 			// timestamp in milliseconds, update event
 			event.ReceivedAt = time.UnixMilli(timeInt).UTC()
-			event.Message = strings.TrimSpace(event.Message[len(timestampStr):])
 		}
 	}
 

--- a/systemapi/server_test.go
+++ b/systemapi/server_test.go
@@ -188,9 +188,9 @@ func TestAddEntryMessageParsing(t *testing.T) {
 	testTime2TimestampMs := testTime2.UnixMilli()
 
 	// Add messages
-	srv.addEvent(Event{ReceivedAt: testTime1, Message: "1"})                                                // regular message
-	srv.addEvent(Event{ReceivedAt: testTime1, Message: fmt.Sprintf("%d 2", testTime2TimestampSec)})         // custom timestamp
-	srv.addEvent(Event{ReceivedAt: testTime1, Message: fmt.Sprintf("%d \t  3  \t ", testTime2TimestampMs)}) // custom timestamp, with whitespace to test trimming
+	srv.addEvent(Event{ReceivedAt: testTime1, Message: "1"})                                                 // regular message
+	srv.addEvent(Event{ReceivedAt: testTime1, Message: fmt.Sprintf("%d 2", testTime2TimestampSec)})          // custom timestamp
+	srv.addEvent(Event{ReceivedAt: testTime1, Message: fmt.Sprintf("  %d \t 3  \t ", testTime2TimestampMs)}) // custom timestamp, with whitespace to test trimming
 
 	// Add empty messages to ensure they are ignored
 	srv.addEvent(Event{ReceivedAt: testTime1, Message: ""})      // empty message
@@ -204,10 +204,10 @@ func TestAddEntryMessageParsing(t *testing.T) {
 	require.Equal(t, testTime1, srv.events[0].ReceivedAt)
 
 	// Check entry 2 (timestamp in seconds)
-	require.Equal(t, "2", srv.events[1].Message)
+	require.Equal(t, fmt.Sprintf("%d 2", testTime2TimestampSec), srv.events[1].Message)
 	require.Equal(t, testTime2, srv.events[1].ReceivedAt)
 
 	// Check entry 3 (timestamp in milliseconds)
-	require.Equal(t, "3", srv.events[2].Message) // check that whitespace was trimmed
+	require.Equal(t, fmt.Sprintf("%d \t 3", testTime2TimestampMs), srv.events[2].Message) // check that whitespace was trimmed
 	require.Equal(t, testTime2, srv.events[2].ReceivedAt)
 }

--- a/systemapi/vars.go
+++ b/systemapi/vars.go
@@ -1,5 +1,0 @@
-package systemapi
-
-import "github.com/flashbots/system-api/common"
-
-var DefaultLogMaxEntries = common.GetEnvInt("MAX_EVENTS", 1000)

--- a/systemapi/vars.go
+++ b/systemapi/vars.go
@@ -1,0 +1,5 @@
+package systemapi
+
+import "github.com/flashbots/system-api/common"
+
+var DefaultLogMaxEntries = common.GetEnvInt("MAX_EVENTS", 1000)


### PR DESCRIPTION
## 📝 Summary

Allow custom timestamps in the event log.

If a message is prefixed with a timestamp (in sec or ms), then that part is used for `ReceivedAt` and the message is the remainder of the original message:

```bash
# Start the server
$ go run cmd/system-api/main.go

# Add regular event
$ echo "hello world" > pipe.fifo

# Add event with custom timestamp
$ echo "1634966400 this is a test" > pipe.fifo

# Query events
$ curl localhost:3535/logs
2024-11-21T19:48:04Z     hello world
2021-10-23T05:20:00Z     1634966400 this is a test      <--- custom timestamp on this entry
```

## Motivation

Some services might log into an (async) named pipe already before system-api has started. Without custom timestamps, those log entries would all have the timestamp when system-api started, instead of when the log message was written.

## Downsides

Allows services to mess with internals through the log message, and spoof the timestamp of it's own event arbitrarily.

## Discussion

Not yet sure what's the best path forward -- giving services this freedom, or simply not having 'proper' timestamps for logs received before system-api start.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
