### PR TITLE
Use --data-binary for curl file upload examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl localhost:3535/api/v1/new_event?message=this+is+a+test
 curl -v localhost:3535/api/v1/actions/echo_test
 
 # upload files
-curl -v -X POST -d "@README.md" localhost:3535/api/v1/file-upload/testfile
+curl -v --data-binary "@README.md" localhost:3535/api/v1/file-upload/testfile
 
 # get event log
 curl localhost:3535/logs
@@ -98,7 +98,7 @@ File uploads are recorded in the event log.
 $ go run cmd/system-api/main.go --config systemapi-config.toml
 
 # Execute the example action
-$ curl -v -X POST -d "@README.md" localhost:3535/api/v1/file-upload/testfile
+$ curl -v --data-binary "@README.md" localhost:3535/api/v1/file-upload/testfile
 ```
 
 ---


### PR DESCRIPTION
## 📝 Summary

Use `--data-binary` flag for curl file upload examples.

## ⛱ Motivation and Context

- `-d` or `--data-ascii` does not preserve newlines and carriage returns.
- remove `-X POST` at it is assumed when `--data-binary` flag is in use.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
